### PR TITLE
Use babel instead of babel-plugin in the build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 *~
+*.swp

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^2.2.5"
   },
   "scripts": {
-    "build": "babel-plugin build",
+    "build": "babel src --out-dir lib",
     "push": "babel-plugin publish",
     "test": "mocha --compilers js:babel-core/register"
   },


### PR DESCRIPTION
babel-plugin has been removed in babel 6.
Still need to update the push script...
#3
